### PR TITLE
Use a platform independent method to detect 64-bit

### DIFF
--- a/bride/Makefile.tarball
+++ b/bride/Makefile.tarball
@@ -8,8 +8,8 @@ TARBALL_URL 	= http://ftp-stud.fht-esslingen.de/pub/Mirrors/eclipse/technology/e
 MD5SUM_FILE 	= eclipse-modeling-kepler-SR1-linux-gtk.tar.gz.md5sum
 
 #64 bit version
-ARCH = $(shell dpkg --print-architecture)
-ifeq ($(ARCH),amd64)
+ARCH = $(shell uname -m)
+ifeq ($(ARCH),x86_64)
 	TARBALL		= build/eclipse-modeling-kepler-SR1-linux-gtk-x86_64.tar.gz
 	TARBALL_URL 	= http://ftp-stud.fht-esslingen.de/pub/Mirrors/eclipse/technology/epp/downloads/release/kepler/SR1/eclipse-modeling-kepler-SR1-linux-gtk-x86_64.tar.gz
 	MD5SUM_FILE 	= eclipse-modeling-kepler-SR1-linux-gtk-x86_64.tar.gz.md5sum	


### PR DESCRIPTION
dpkg is only available on Debian. uname should be available on most all modern Linux distros and OSX.
